### PR TITLE
Added checks for settings.DEBUG to facilitate tests.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,21 @@ The reCAPTCHA widget supports several `Javascript options variables <https://cod
 
 The captcha client takes the key/value pairs and writes out the RecaptchaOptions value in JavaScript.
 
+
+Unit Testing
+~~~~~~~~~~~~
+django-recaptcha detects for `DEBUG = True` in the settings.py to facilitate unit tests.
+When `DEBUG = TRUE`, using `PASSED` as the `recaptcha_response_field` value.
+
+Example:
+
+    form_params = {'recaptcha_response_field': 'PASSED'}
+    form = RegistrationForm(form_params) # assuming only one ReCaptchaField
+    form.is_valid() # True
+
+Passing any other values will cause django-recaptcha to continue normal processing and return a form error.
+
+
 django-registration
 ~~~~~~~~~~~~~~~~~~~
 django-recaptcha ships with a `django-registration <https://bitbucket.org/ubernostrum/django-registration>`_ backend extending the default backend to include a reCAPTCHA field. This is included mostly as an example of how you could intergrate a reCAPTCHA field with django-registration. I suggest you familiarize yourself with `the django-registration docs <http://docs.b-list.org/django-registration/0.8/index.html>`_ for more comprehensive documentation. 

--- a/captcha/fields.py
+++ b/captcha/fields.py
@@ -48,6 +48,10 @@ class ReCaptchaField(forms.CharField):
         super(ReCaptchaField, self).clean(values[1])
         recaptcha_challenge_value = smart_unicode(values[0])
         recaptcha_response_value = smart_unicode(values[1])
+
+        if settings.DEBUG and recaptcha_response_value == 'PASSED':
+            return values[0]
+
         check_captcha = client.submit(recaptcha_challenge_value, \
                 recaptcha_response_value, private_key=self.private_key, \
                 remoteip=self.get_remote_ip(), use_ssl=self.use_ssl)


### PR DESCRIPTION
I have added a check in forms.py's clean method to allow the recaptcha field to be valid when DEBUG = True. This is vital when using django's unit tests as the developer can control whether he wants the field to pass. The value that will automatically be valid when DEBUG = True is "PASSED".

Also, a short paragraph has been added to README.md to let users know how they can use the added check for their unit tests.
