### PR TITLE
Consider a different mechanism for unit testing

### DIFF
--- a/captcha/fields.py
+++ b/captcha/fields.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 from django import forms
@@ -52,7 +53,8 @@ class ReCaptchaField(forms.CharField):
         recaptcha_challenge_value = smart_unicode(values[0])
         recaptcha_response_value = smart_unicode(values[1])
 
-        if settings.DEBUG and recaptcha_response_value == 'PASSED':
+        if os.environ.get('RECAPTCHA_TESTING', None) == 'True' and \
+                recaptcha_response_value == 'PASSED':
             return values[0]
 
         check_captcha = client.submit(recaptcha_challenge_value, \


### PR DESCRIPTION
Django unit tests are typically run with `settings.DEBUG = False`, but the `ReCaptchaField` requires `DEBUG = True` in order to allow `PASSED` to go through.

There are a number of good reasons that Django forces `DEBUG = False` when running tests; you can read more about the reasons in [old Django bug #8401](https://code.djangoproject.com/ticket/8401), amongst other places. (This is an old bug, but modern Django 1.4 still forces `DEBUG = False` when testing.)

I don't like circumventing this on a test-by-test basis. 
