### PR TITLE
django.utils.simplejson is deprecated in Django 1.5

### DIFF
--- a/captcha/client.py
+++ b/captcha/client.py
@@ -1,9 +1,9 @@
+import json
 import urllib
 import urllib2
 
 from django.conf import settings
 from django.template.loader import render_to_string
-from django.utils import simplejson as json
 from django.utils.safestring import mark_safe
 
 DEFAULT_API_SSL_SERVER = "https://www.google.com/recaptcha/api"


### PR DESCRIPTION
The [Django 1.5 release notes](https://docs.djangoproject.com/en/dev/releases/1.5/#system-version-of-simplejson-no-longer-used) state that:

> "Django 1.5 deprecates django.utils.simplejson in favor of Python 2.6’s built-in json module."

This causes `django-recaptcha` to raise an exception when run under Django 1.7 (development snapshot from Git):

```
...

File "/usr/local/lib/python2.7/dist-packages/captcha/fields.py", line 9, in <module>
  from captcha import client

File "/usr/local/lib/python2.7/dist-packages/captcha/client.py", line 6, in <module>
  from django.utils import simplejson as json

ImportError: cannot import name simplejson
```

My pull request simply replaces the import of `django.utils.simple_json` with an import of `json` from the standard library.
