### PR TITLE
Update client.py

### DIFF
--- a/captcha/client.py
+++ b/captcha/client.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.template.loader import render_to_string
 from django.utils import simplejson as json
 from django.utils.safestring import mark_safe
+from django.utils.translation import get_language
 
 DEFAULT_API_SSL_SERVER = "https://www.google.com/recaptcha/api"
 DEFAULT_API_SERVER = "http://www.google.com/recaptcha/api"
@@ -49,7 +50,7 @@ def displayhtml(public_key,
         server = API_SERVER
 
     if not 'lang' in attrs:
-        attrs['lang'] = settings.LANGUAGE_CODE[:2]
+        attrs['lang'] = get_language()[:2]
 
     return render_to_string(WIDGET_TEMPLATE,
             {'api_server': server,


### PR DESCRIPTION
Hi praekelt!
We have a problem with current language.

```
class SupportForm(BootstrapForm):
    # other fields
    captcha = ReCaptchaField(label=_(u'Are you human?'), attrs={'lang': get_language(), 'theme': 'white'}
    )
```

On production server we have the same message 
![recaptcha-error](https://f.cloud.github.com/assets/380957/1333902/b5b2f764-359e-11e3-827f-2803494e1933.jpg)

Example pages:
- [ru page](http://postmanbot.com/ru/support/)
- [en page](http://postmanbot.com/en/support/)

We offer in [string](https://github.com/praekelt/django-recaptcha/blob/master/captcha/client.py#L51-L52)

```
    if not 'lang' in attrs:
        attrs['lang'] = settings.LANGUAGE_CODE[:2]
```

change to

```
    if not 'lang' in attrs:
        attrs['lang'] = get_language()[:2]
```
