### PR TITLE
DeprecationWarning: django.utils.simplejson is deprecated

### DIFF
--- a/captcha/client.py
+++ b/captcha/client.py
@@ -3,7 +3,7 @@ import urllib2
 
 from django.conf import settings
 from django.template.loader import render_to_string
-from django.utils import simplejson as json
+import json
 from django.utils.safestring import mark_safe
 
 DEFAULT_API_SSL_SERVER = "https://www.google.com/recaptcha/api"


### PR DESCRIPTION
`django.utils.simplejson` si deprecated. Now `json` gets imported instead.
