### PR TITLE
Fixing missing options.html issue

### DIFF
--- a/captcha/templates/captcha/widget_ajax.html
+++ b/captcha/templates/captcha/widget_ajax.html
@@ -1,11 +1,11 @@
-{% include "captcha/options.html" %}
 
 {# import recaptcha_ajax.js in your body  #} 
 {# <script type="text/javascript" src="http://www.google.com/recaptcha/api/js/recaptcha_ajax.js"></script> #}
 
 <div id="Recap"></div>
 <script type="text/javascript">
-Recaptcha.create("{{ public_key }}",
+  var RecaptchaOptions = {{options}};
+  Recaptcha.create("{{ public_key }}",
     "Recap",
     {
       theme: "red",


### PR DESCRIPTION
This fix comes from issue #34 due to PR #14.
"options.html" was created to factorize code from widget.html and ajax_widget.html in zalew repository, but some code there has not been committed (changes in widget.html too).
As I have not tested zalew branch, I prefer PR a fix for this bug now. Some factorization can be done later.
