### PR TITLE
Used try/except block for importing json versus simplejson

### DIFF
--- a/captcha/client.py
+++ b/captcha/client.py
@@ -1,7 +1,6 @@
-import django
-if django.VERSION[1] >= 5:
+try:
     import json
-else:
+except ImportError:
     from django.utils import simplejson as json
 
 from django.conf import settings


### PR DESCRIPTION
The current code will fail starting with Django 2.0 as it only checks the point release version being equal to 5 or higher. This patch uses a try/except block which is NOT dependent on looking for a specific version of Django and therefore is less prone to breakage. If json is not available, than fall back to simplejson.  This is more accepted way of handling this type of issue.