### PR TITLE
fixes TypeError in python 3

### DIFF
--- a/captcha/client.py
+++ b/captcha/client.py
@@ -135,7 +135,10 @@ def submit(recaptcha_challenge_field,
 
     httpresp = urlopen(req)
     if getattr(settings, "NOCAPTCHA", False):
-        data = json.load(httpresp)
+        if not PY2:
+            data = json.loads(httpresp.read().decode('utf-8'))
+        else:
+            data = json.load(httpresp)
         return_code = data['success']
         return_values = [return_code, None]
         if return_code:
@@ -143,13 +146,13 @@ def submit(recaptcha_challenge_field,
         else:
             return_code = 'false'
     else:
-        return_values = httpresp.read().splitlines()
+        if not PY2:
+            return_values = httpresp.read().decode('utf-8').splitlines()
+        else:
+            return_values = httpresp.read().splitlines()
         return_code = return_values[0]
 
     httpresp.close()
-
-    if not PY2:
-        return_code = return_code.decode('utf-8')
 
     if (return_code == "true"):
         return RecaptchaResponse(is_valid=True)


### PR DESCRIPTION
In python 3, an error is thrown when trying to verify the captcha is valid: `the JSON object must be str, not 'bytes'`

Turns out, the response from `urllib.request.urlopen` is read in binary mode, but `json.load` requires a string, which causes a `TypeError`. As such, the response data needs to be decoded before parsing.