### PR TITLE
Add proxy support and Python 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: python
 install:
-  - pip install tox 
+  - pip install tox
 script:
   - tox
 env:
-  - TOXENV=django14
-  - TOXENV=django15
-  - TOXENV=django16
-  - TOXENV=django17
-
+  - TOXENV=py27-1.4
+  - TOXENV=py27-1.5
+  - TOXENV=py27-1.6
+  - TOXENV=py27-1.7
+  - TOXENV=py33-1.5
+  - TOXENV=py33-1.6
+  - TOXENV=py33-1.7
+  - TOXENV=py34-1.5
+  - TOXENV=py34-1.6
+  - TOXENV=py34-1.7

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,10 @@ Installation
    If you don't add this setting the default behaviour is to **NOT** use SSL. Note that if you have ``NOCAPTCHA = True`` set, SSL will always be used.
    This can be seperately specified at runtime by passing a ``use_ssl`` parameter when constructing the ``ReCaptchaField``, see field usage below.
 
+#. If you require a proxy, add a ``RECAPTCHA_PROXY`` setting to the project's ``settings.py`` file, i.e.::
+
+    RECAPTCHA_PROXY = 'http://127.0.0.1:8000'
+
 Usage
 -----
 

--- a/captcha/_compat.py
+++ b/captcha/_compat.py
@@ -3,10 +3,10 @@ import sys
 PY2 = sys.version_info[0] == 2
 if PY2:
     text_type = unicode
-    from urllib2 import Request, urlopen
+    from urllib2 import build_opener, ProxyHandler, Request, urlopen
     from urllib import urlencode
 else:
-    from urllib.request import Request, urlopen
+    from urllib.request import build_opener, ProxyHandler, Request, urlopen
     from urllib.parse import urlencode
     text_type = str
 

--- a/captcha/client.py
+++ b/captcha/client.py
@@ -157,7 +157,7 @@ def submit(recaptcha_challenge_field,
         else:
             return_code = 'false'
     else:
-        return_values = httpresp.read().splitlines()
+        return_values = httpresp.read().decode('utf-8').splitlines()
         return_code = return_values[0]
 
     httpresp.close()

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,17 @@
 [tox]
 envlist =
-    django17,
-    django16,
-    django15,
-    django14
+    {py27,py32,py33,py34}-{1.5,1.6.1.7},
+    py27-django14
 
 [testenv]
-basepython = python2.7
+basepython =
+    py27: python2.7
+    py33: python3.3
+    py34: python3.4
 commands=python setup.py test
-
-[testenv:django17]
-deps = django>=1.7,<1.8
-
-[testenv:django16]
-deps = django>=1.6,<1.7
-
-[testenv:django15]
-deps = django>=1.5,<1.6
-
-[testenv:django14]
-deps = django>=1.4,<1.5
+deps =
+    1.4: Django>=1.4,<1.5
+    1.5: Django>=1.5,<1.6
+    1.6: Django>=1.6,<1.7
+    1.7: Django>=1.7,<1.8
+    1.8: Django<1.9


### PR DESCRIPTION
Similar to #42 but also:
* Adds Python 3 support and CI builds
* Only installs the proxy for the reCaptcha request, not for urllib globally 
* Includes an updated readme

Note that the current syntax does not allow testing with Python 3.2, and `django-setuptest` does not allow for testing with Django 1.8.