### PR TITLE
bugfix: the widget was always rendered in the first used language because attrs was ReCaptcha.js_attrs

### DIFF
--- a/captcha/client.py
+++ b/captcha/client.py
@@ -60,15 +60,12 @@ def displayhtml(public_key,
     else:
         server = API_SERVER
 
-    if 'lang' not in attrs:
-        attrs['lang'] = get_language()[:2]
-
     return render_to_string(
         WIDGET_TEMPLATE,
         {'api_server': server,
          'public_key': public_key,
          'error_param': error_param,
-         'lang': attrs['lang'],
+         'lang': attrs.get('lang') or get_language()[:2],
          'options': mark_safe(json.dumps(attrs, indent=2))
          })
 

--- a/captcha/fields.py
+++ b/captcha/fields.py
@@ -23,7 +23,7 @@ class ReCaptchaField(forms.CharField):
     }
 
     def __init__(self, public_key=None, private_key=None, use_ssl=None,
-                 attrs={}, *args, **kwargs):
+                 attrs=None, *args, **kwargs):
         """
         ReCaptchaField can accepts attributes which is a dictionary of
         attributes to be passed to the ReCaptcha widget class. The widget will
@@ -31,6 +31,8 @@ class ReCaptchaField(forms.CharField):
         JavaScript variables as specified in
         https://code.google.com/apis/recaptcha/docs/customization.html
         """
+        if attrs is None:
+            attrs = {}
         public_key = public_key if public_key else \
             settings.RECAPTCHA_PUBLIC_KEY
         self.private_key = private_key if private_key else \

--- a/captcha/widgets.py
+++ b/captcha/widgets.py
@@ -13,9 +13,11 @@ class ReCaptcha(forms.widgets.Widget):
         recaptcha_challenge_name = 'recaptcha_challenge_field'
         recaptcha_response_name = 'recaptcha_response_field'
 
-    def __init__(self, public_key=None, use_ssl=None, attrs={}, *args,
+    def __init__(self, public_key=None, use_ssl=None, attrs=None, *args,
                  **kwargs):
         self.public_key = public_key or settings.RECAPTCHA_PUBLIC_KEY
+        if attrs is None:
+            attrs = {}
         self.use_ssl = use_ssl if use_ssl is not None else getattr(
             settings, 'RECAPTCHA_USE_SSL', False)
         self.js_attrs = attrs


### PR DESCRIPTION
Whe you have a multilingual site, there is a bug: the widget is always rendered in the same language that it was rendered the first time. This is because the "attrs" dict passed to displayhtml is ReCaptcha.js_attrs and a widget is only initialized once.

displayhtml was modifying this dict here:
```python
if 'lang' not in attrs:
    attrs['lang'] = get_language()[:2]
```
so in each further call to displayhtml, attrs['lang'] was already set.