### PR TITLE
Update readme -- needed LocaleMiddleware in Django 1.9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,8 @@ Installation
 
 #. Add ``captcha`` to your ``INSTALLED_APPS`` setting.
 
+#. Add ``django.middleware.locale.LocaleMiddleware`` to your ``MIDDLEWARE_CLASSES`` setting. 
+
 #. Add a ``RECAPTCHA_PUBLIC_KEY`` setting to the project's ``settings.py`` file. This is your public API key as provided by reCAPTCHA, i.e.::
 
     RECAPTCHA_PUBLIC_KEY = '76wtgdfsjhsydt7r5FFGFhgsdfytd656sad75fgh'


### PR DESCRIPTION
Received an error on line 64 of client.py, which does not catch a NoneType response from `django.utils.translation.get_language()`. The get_language method only seems to return None when translation support is not enabled. Thus, the Django `LocaleMiddleware` must be in `MIDDLEWARE_CLASSES` for this application to function properly in Django 1.9.7 (have not tested with other versions of Django).
