### PR TITLE
Options should now be set using data- attributes, RecaptchaOptions is…

### DIFF
--- a/captcha/client.py
+++ b/captcha/client.py
@@ -69,7 +69,8 @@ def displayhtml(public_key,
          'public_key': public_key,
          'error_param': error_param,
          'lang': attrs['lang'],
-         'options': mark_safe(json.dumps(attrs, indent=2))
+         'options': mark_safe(json.dumps(attrs, indent=2)),
+         'options_dict': attrs
          })
 
 

--- a/captcha/templates/captcha/widget_nocaptcha.html
+++ b/captcha/templates/captcha/widget_nocaptcha.html
@@ -1,15 +1,5 @@
 <script src='https://www.google.com/recaptcha/api.js{% if lang %}?hl={{ lang }}{% endif %}'></script>
-<script type="text/javascript">
-    var DjangoRecaptchaOptions = {{options}};
-    if (typeof RecaptchaOptions !== 'object') {
-        RecaptchaOptions = DjangoRecaptchaOptions;
-    } else {
-        for (key in DjangoRecaptchaOptions) {
-            RecaptchaOptions[key] = DjangoRecaptchaOptions[key];
-        }
-    }
-</script>
-<div class="g-recaptcha" data-sitekey="{{ public_key }}"></div>
+<div class="g-recaptcha" data-sitekey="{{ public_key }}" {% for option,value in options_dict.items %}data-{{ option }}="{{ value }}" {% endfor %}></div>
 <noscript>
   <div style="width: 302px; height: 352px;">
     <div style="width: 302px; height: 352px; position: relative;">


### PR DESCRIPTION
Hi Hedley

Google no longer uses the RecaptchaOptions JavaScript object to set options, it must now be set using data- attributes.

I changed the code to pass the options dictionary to the template and the template to populate the data- attributes.

As far as I can see it is 100% backwards compatible, please merge.

Thanks
Gert
