### PR TITLE
Tidy up README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,9 @@ Django reCAPTCHA
 .. contents:: Contents
     :depth: 5
 
-django-recaptcha uses a modified version of the `Python reCAPTCHA client <http://pypi.python.org/pypi/recaptcha-client>`_ which is included in the package as ``client.py``.
+Django reCAPTCHA uses a modified version of the `Python reCAPTCHA client
+<http://pypi.python.org/pypi/recaptcha-client>`_ which is included in the
+package as ``client.py``.
 
 
 Requirements
@@ -22,33 +24,31 @@ Tested with:
 Installation
 ------------
 
+#. `Sign up for reCAPTCHA <https://www.google.com/recaptcha/intro/index.html>`_.
+
 #. Install or add ``django-recaptcha`` to your Python path.
 
-#. Add ``captcha`` to your ``INSTALLED_APPS`` setting.
+#. Add ``'captcha'`` to your ``INSTALLED_APPS`` setting.
 
-#. Add a ``RECAPTCHA_PUBLIC_KEY`` setting to the project's ``settings.py`` file. This is your public API key as provided by reCAPTCHA, i.e.:
-
-   .. code-block:: python
-
-       RECAPTCHA_PUBLIC_KEY = '76wtgdfsjhsydt7r5FFGFhgsdfytd656sad75fgh'
-
-   This can be seperately specified at runtime by passing a ``public_key`` parameter when constructing the ``ReCaptchaField``, see field usage below.
-
-#. Add a ``RECAPTCHA_PRIVATE_KEY`` setting to the project's ``settings.py`` file. This is your private API key as provided by reCAPTCHA, i.e.:
+#. Add the keys reCAPTCHA have given you to your Django settings as
+   ``RECAPTCHA_PUBLIC_KEY`` and ``RECAPTCHA_PRIVATE_KEY``. For example:
 
    .. code-block:: python
 
-       RECAPTCHA_PRIVATE_KEY = '98dfg6df7g56df6gdfgdfg65JHJH656565GFGFGs'
+       RECAPTCHA_PUBLIC_KEY = 'MyRecaptchaKey123'
+       RECAPTCHA_PRIVATE_KEY = 'MyRecaptchaPrivateKey456'
 
-   This can be seperately specified at runtime by passing a ``private_key`` parameter when constructing the ``ReCaptchaField``, see field usage below.
+   These can also be specificied per field by passing the ``public_key`` or
+   ``private_key`` parameters to ``ReCaptchaField`` - see field usage below.
 
-#. If you would like to use the new No Captcha reCaptcha add a ``NOCAPTCHA = True`` setting to the project's ``settings.py`` file. ie.:
+#. If you would like to use the new No Captcha reCaptcha add the setting
+   ``NOCAPTCHA = True``. For example:
 
    .. code-block:: python
 
        NOCAPTCHA = True
 
-#. If you require a proxy, add a ``RECAPTCHA_PROXY`` setting to the project's ``settings.py`` file, i.e.:
+#. If you require a proxy, add a ``RECAPTCHA_PROXY`` setting, for example:
 
    .. code-block:: python
 
@@ -59,7 +59,10 @@ Usage
 
 Field
 ~~~~~
-The quickest way to add reCAPTCHA to a form is to use the included ``ReCaptchaField`` field class. A ``ReCaptcha`` widget will be rendered with the field validating itself without any further action required from you. For example:
+
+The quickest way to add reCAPTCHA to a form is to use the included
+``ReCaptchaField`` field class. A ``ReCaptcha`` widget will be rendered with
+the field validating itself without any further action required. For example:
 
 .. code-block:: python
 
@@ -69,7 +72,8 @@ The quickest way to add reCAPTCHA to a form is to use the included ``ReCaptchaFi
     class FormWithCaptcha(forms.Form):
         captcha = ReCaptchaField()
 
-To allow for runtime specification of keys and SSL usage you can optionally pass the ``private_key`` or ``public_key`` parameters to the constructor. For example:
+To allow for runtime specification of keys you can optionally pass the
+``private_key`` or ``public_key`` parameters to the constructor. For example:
 
 .. code-block:: python
 
@@ -78,27 +82,37 @@ To allow for runtime specification of keys and SSL usage you can optionally pass
         private_key='98dfg6df7g56df6gdfgdfg65JHJH656565GFGFGs',
     )
 
-If specified these parameters will be used instead of your reCAPTCHA project settings.
+If specified these parameters will be used instead of your reCAPTCHA project
+settings.
 
-The reCAPTCHA widget supports several `Javascript options variables <https://developers.google.com/recaptcha/docs/display#js_param>`_ customizing the behaviour of the widget, such as ``theme`` and ``lang``. You can forward these options to the widget by passing an ``attr`` parameter containing a dictionary of options to ``ReCaptchaField``. For example:
+The reCAPTCHA widget supports several `Javascript options variables
+<https://developers.google.com/recaptcha/docs/display#js_param>`_ that
+customize the behaviour of the widget, such as ``theme`` and ``lang``. You can
+forward these options to the widget by passing an ``attr`` parameter to the
+field, containing a dictionary of options. For example:
 
 .. code-block:: python
 
-    captcha = ReCaptchaField(attrs={'theme' : 'clean'})
+    captcha = ReCaptchaField(attrs={
+      'theme' : 'clean',
+    })
 
-The captcha client takes the key/value pairs and writes out the RecaptchaOptions value in JavaScript.
+The client takes the key/value pairs and writes out the ``RecaptchaOptions``
+value in JavaScript.
 
 
 Unit Testing
 ~~~~~~~~~~~~
 
-django-recaptcha introduces an environmental variable ``RECAPTCHA_TESTING`` which
-helps facilitate tests. The environmental variable should be set to ``"True"``,
-and cleared, using the ``setUp()`` and ``tearDown()`` methods in your test classes.
+Django reCAPTCHA introduces an environment variable ``RECAPTCHA_TESTING`` which
+helps facilitate tests. The environment variable should be set to ``"True"``,
+and cleared, using the ``setUp()`` and ``tearDown()`` methods in your test
+classes.
 
-Setting ``RECAPTCHA_TESTING`` to ``True`` causes django-recaptcha to accept
-``"PASSED"`` as the ``recaptcha_response_field`` value. Note that if you are using the new No Captcha reCaptcha
-(ie. with ``NOCAPTCHA = True`` in your settings) the response field is called ``g-recaptcha-response``.
+Setting ``RECAPTCHA_TESTING`` to ``True`` causes Django reCAPTCHA to accept
+``"PASSED"`` as the ``recaptcha_response_field`` value. Note that if you are
+using the new No Captcha reCaptcha (ie. with ``NOCAPTCHA = True`` in your
+settings) the response field is called ``g-recaptcha-response``.
 
 Example:
 
@@ -114,8 +128,8 @@ Example:
     os.environ['RECAPTCHA_TESTING'] = 'False'
     form.is_valid() # False
 
-Passing any other values will cause django-recaptcha to continue normal processing
-and return a form error.
+Passing any other values will cause Django reCAPTCHA to continue normal
+processing and return a form error.
 
 Check ``tests.py`` for a full example.
 
@@ -123,7 +137,7 @@ Check ``tests.py`` for a full example.
 AJAX
 ~~~~~
 
-To make Recapcha work in ajax-loaded forms:
+To make reCAPTCHA work in ajax-loaded forms:
 
 #. Import ``recaptcha_ajax.js`` on your page (not in the loaded template):
 
@@ -135,23 +149,28 @@ To make Recapcha work in ajax-loaded forms:
 
    .. code-block:: python
 
-
        CAPTCHA_AJAX = True
 
 
 Disabling SSL
 ~~~~~~~~~~~~~
 
-This library used to not use SSL by default, but now it does. You can disable this if required, but you should think long and hard about it before you do so!
+This library used to not use SSL by default, but now it does. You can disable
+this if required, but you should think long and hard about it before you do so!
 
-You can disable it by setting ``RECAPTCHA_USE_SSL = False`` in your Django settings, or by passing ``use_ssl=False`` to the constructor of ``ReCaptchaField``.
+You can disable it by setting ``RECAPTCHA_USE_SSL = False`` in your Django
+settings, or by passing ``use_ssl=False`` to the constructor of
+``ReCaptchaField``.
 
 
 Credits
 -------
-Inspired Marco Fucci's blogpost titled `Integrating reCAPTCHA with Django <http://www.marcofucci.com/tumblelog/26/jul/2009/integrating-recaptcha-with-django>`_
+Inspired Marco Fucci's blogpost titled `Integrating reCAPTCHA with Django
+<http://www.marcofucci.com/tumblelog/26/jul/2009/integrating-recaptcha-with-django>`_
 
 
-``client.py`` taken from `recaptcha-client <http://pypi.python.org/pypi/recaptcha-client>`_ licenced MIT/X11 by Mike Crawford.
+``client.py`` taken from `recaptcha-client
+<http://pypi.python.org/pypi/recaptcha-client>`_ licenced MIT/X11 by Mike
+Crawford.
 
 reCAPTCHA copyright 2012 Google.


### PR DESCRIPTION
* Wrap at 80 chars
* Consistently use the name 'Django reCAPTCHA'
* Add an installation step about signing up for reCAPTCHA, and use obviously broken public/private keys, to fix the confusion as in #32.
* Reword some bits.