### PR TITLE
Adding test key support as defaults

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Installation
 
 #. Add ``'captcha'`` to your ``INSTALLED_APPS`` setting.
 
-#. Add the keys reCAPTCHA have given you to your Django settings as
+#. Add the keys reCAPTCHA have given you to your Django production settings (leave development settings blank to use the default test keys) as
    ``RECAPTCHA_PUBLIC_KEY`` and ``RECAPTCHA_PRIVATE_KEY``. For example:
 
    .. code-block:: python
@@ -99,6 +99,12 @@ field, containing a dictionary of options. For example:
 
 The client takes the key/value pairs and writes out the ``RecaptchaOptions``
 value in JavaScript.
+
+
+Local Development and Functional Testing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Google provides test keys which are set as the default for ``RECAPTCHA_PUBLIC_KEY`` and ``RECAPTCHA_PRIVATE_KEY``. These cannot be used in production since they always validate to true and a warning will be shown on the reCAPTCHA. 
 
 
 Unit Testing

--- a/captcha/fields.py
+++ b/captcha/fields.py
@@ -34,9 +34,9 @@ class ReCaptchaField(forms.CharField):
         if attrs is None:
             attrs = {}
         public_key = public_key if public_key else \
-            settings.RECAPTCHA_PUBLIC_KEY
+            getattr(settings, 'RECAPTCHA_PUBLIC_KEY', '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI')
         self.private_key = private_key if private_key else \
-            settings.RECAPTCHA_PRIVATE_KEY
+            getattr(settings, 'RECAPTCHA_PRIVATE_KEY', '6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe')
         self.use_ssl = use_ssl if use_ssl is not None else getattr(
             settings, 'RECAPTCHA_USE_SSL', True)
 

--- a/captcha/widgets.py
+++ b/captcha/widgets.py
@@ -15,7 +15,7 @@ class ReCaptcha(forms.widgets.Widget):
 
     def __init__(self, public_key=None, use_ssl=None, attrs=None, *args,
                  **kwargs):
-        self.public_key = public_key or settings.RECAPTCHA_PUBLIC_KEY
+        self.public_key = public_key or getattr(settings, 'RECAPTCHA_PUBLIC_KEY', '6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI')
         if attrs is None:
             attrs = {}
         self.use_ssl = use_ssl if use_ssl is not None else getattr(


### PR DESCRIPTION
Google now provides a test RECAPTCHA_PRIVATE_KEY and RECAPTCHA_PUBLIC_KEY. For more info, see https://developers.google.com/recaptcha/docs/faq