### PR TITLE
Fix compatibility with django-fobi (and probably with others)

### DIFF
--- a/captcha/widgets.py
+++ b/captcha/widgets.py
@@ -18,9 +18,9 @@ class ReCaptcha(forms.widgets.Widget):
 
     template_name = WIDGET_TEMPLATE
 
-    def __init__(self, public_key, *args, **kwargs):
+    def __init__(self, public_key=None, *args, **kwargs):
         super(ReCaptcha, self).__init__(*args, **kwargs)
-        self.public_key = public_key
+        self.public_key = public_key or getattr(settings, 'RECAPTCHA_PUBLIC_KEY', TEST_PUBLIC_KEY)
 
     def value_from_datadict(self, data, files, name):
         return [


### PR DESCRIPTION
Django-recaptcha [stoped allowing empty public_key](https://github.com/praekelt/django-recaptcha/commit/d14e74484c31248faa225bea2c8c73606bc7baa5#diff-c419a344693796552e0dd3efa4d4baa0L17) this produces [an error](https://github.com/barseghyanartur/django-fobi/issues/157) at django-fobi
I think it's a good idea to allow public_key=None and default to default settings