### PR TITLE
feature/GH-176: Moved field test key check to an app ready registered check. Marked as a security check, requires setting var to ignore.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,9 +46,7 @@ Installation
             ...
         ]
 
-#. Add the Google reCAPTCHA keys generated in step 1 to your Django production settings.
-Note that omitting these settings will default to a set of test keys which can be used for development.``RECAPTCHA_PUBLIC_KEY`` and ``RECAPTCHA_PRIVATE_KEY``.
-Ensure ``SILENCED_SYSTEM_CHECKS = [..., 'captcha.recaptcha_test_key_error', ...]`` is set to bypass the security check that prevents the test keys from being used unknowingly.
+#. Add the Google reCAPTCHA keys generated in step 1 to your Django production settings. Note that omitting these settings will default to a set of test keys which can be used for development.``RECAPTCHA_PUBLIC_KEY`` and ``RECAPTCHA_PRIVATE_KEY``. Also ensure ``SILENCED_SYSTEM_CHECKS = [..., 'captcha.recaptcha_test_key_error', ...]`` is set to bypass the security check that prevents the test keys from being used unknowingly.
 
     For example:
 

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Installation
             ...
         ]
 
-#. Add the Google reCAPTCHA keys generated in step 1 to your Django production settings. Note that omitting these settings will default to a set of test keys which can be used for development.``RECAPTCHA_PUBLIC_KEY`` and ``RECAPTCHA_PRIVATE_KEY``. Also ensure ``SILENCED_SYSTEM_CHECKS = [..., 'captcha.recaptcha_test_key_error', ...]`` is set to bypass the security check that prevents the test keys from being used unknowingly.
+#. Add the Google reCAPTCHA keys generated in step 1 to your Django production settings with ``RECAPTCHA_PUBLIC_KEY`` and ``RECAPTCHA_PRIVATE_KEY``. Note that omitting these settings will default to a set of test keys refer to `Local Development and Functional Testing <Local Development and Functional Testing_>`_ for more information.
 
     For example:
 
@@ -179,6 +179,11 @@ Local Development and Functional Testing
 
 Google provides test keys which are set as the default for ``RECAPTCHA_PUBLIC_KEY`` and ``RECAPTCHA_PRIVATE_KEY``. These cannot be used in production since they always validate to true and a warning will be shown on the reCAPTCHA.
 
+To bypass the security check that prevents the test keys from being used unknowingly add ``SILENCED_SYSTEM_CHECKS = [..., 'captcha.recaptcha_test_key_error', ...]`` to you settings, here is an example:
+
+    .. code-block:: python
+
+        SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error']
 
 Credits
 -------

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,9 @@ Installation
             ...
         ]
 
-#. Add the Google reCAPTCHA keys generated in step 1 to your Django production settings. Note that omitting these settings will default to a set of test keys which can be used for development.``RECAPTCHA_PUBLIC_KEY`` and ``RECAPTCHA_PRIVATE_KEY``.
+#. Add the Google reCAPTCHA keys generated in step 1 to your Django production settings.
+Note that omitting these settings will default to a set of test keys which can be used for development.``RECAPTCHA_PUBLIC_KEY`` and ``RECAPTCHA_PRIVATE_KEY``.
+Ensure ``SILENCED_SYSTEM_CHECKS = [..., 'captcha.recaptcha_test_key_error', ...]`` is set to bypass the security check that prevents the test keys from being used unknowingly.
 
     For example:
 

--- a/captcha/__init__.py
+++ b/captcha/__init__.py
@@ -17,3 +17,5 @@ for variable, instance_type in SETTINGS_TYPES.items():
         raise ImproperlyConfigured(
             "Setting %s is not of type" % variable, instance_type
         )
+
+default_app_config = "captcha.apps.CaptchaConfig"

--- a/captcha/apps.py
+++ b/captcha/apps.py
@@ -1,0 +1,12 @@
+from django.apps import AppConfig
+from django.core.checks import register, Tags
+
+from captcha.checks import recaptcha_key_check
+
+
+class CaptchaConfig(AppConfig):
+    name = "captcha"
+    verbose_name = "Django reCAPTCHA"
+
+    def ready(self):
+        register(recaptcha_key_check, Tags.security)

--- a/captcha/checks.py
+++ b/captcha/checks.py
@@ -1,0 +1,27 @@
+from django.conf import settings
+from django.core import checks
+
+from captcha.constants import TEST_PRIVATE_KEY, TEST_PUBLIC_KEY
+
+
+def recaptcha_key_check(app_configs, **kwargs):
+    errors = []
+    private_key = getattr(
+        settings, "RECAPTCHA_PRIVATE_KEY", TEST_PRIVATE_KEY)
+    public_key = getattr(
+        settings, "RECAPTCHA_PUBLIC_KEY", TEST_PUBLIC_KEY)
+
+    if private_key == TEST_PRIVATE_KEY or \
+            public_key == TEST_PUBLIC_KEY:
+        errors.extend([checks.Error(
+            "RECAPTCHA_PRIVATE_KEY or RECAPTCHA_PUBLIC_KEY is making use"
+            " of the Google test keys and will not behave as expected in a"
+            " production environment",
+            hint="Update settings.RECAPTCHA_PRIVATE_KEY"
+            " and/or settings.RECAPTCHA_PUBLIC_KEY. Alternatively this check"
+            " can be ignored by adding"
+            " `SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error']`"
+            " to your settings file.",
+            id="captcha.recaptcha_test_key_error"
+        )])
+    return errors

--- a/captcha/fields.py
+++ b/captcha/fields.py
@@ -52,16 +52,6 @@ class ReCaptchaField(forms.CharField):
         self.public_key = public_key or getattr(
             settings, "RECAPTCHA_PUBLIC_KEY", TEST_PUBLIC_KEY)
 
-        if self.private_key == TEST_PRIVATE_KEY or \
-                self.public_key == TEST_PUBLIC_KEY:
-            warnings.warn(
-                "RECAPTCHA_PRIVATE_KEY or RECAPTCHA_PUBLIC_KEY is making use"
-                " of the Google test keys and will not behave as expected in a"
-                " production environment",
-                RuntimeWarning,
-                2
-            )
-
         # Update widget attrs with data-sitekey.
         self.widget.attrs["data-sitekey"] = self.public_key
 

--- a/captcha/tests/test_fields.py
+++ b/captcha/tests/test_fields.py
@@ -91,19 +91,6 @@ class TestFields(TestCase):
             ["Error verifying reCAPTCHA, please try again."]
         )
 
-    @override_settings(RECAPTCHA_PRIVATE_KEY=constants.TEST_PRIVATE_KEY)
-    def test_test_key_warning(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-
-            class ImporperForm(forms.Form):
-                captcha = fields.ReCaptchaField()
-
-            assert len(w) == 1
-            assert issubclass(w[-1].category, RuntimeWarning)
-            assert "RECAPTCHA_PRIVATE_KEY or RECAPTCHA_PUBLIC_KEY" in str(
-                w[-1].message)
-
 
 class TestWidgets(TestCase):
     @patch("captcha.widgets.uuid.UUID.hex", new_callable=PropertyMock)


### PR DESCRIPTION
Moved field _init__ based test key warning check to an app ready registered django check framework, check.

It is now marked as a security check. This will cause existing instances that use the test keys to fail the check and subsequently most management commands will halt, including runserver.
`SILENCED_SYSTEM_CHECKS = ['captcha.recaptcha_test_key_error']` will need to be set in settings to ignore the check.