### PR TITLE
Django 3 and Python 3.8 Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,8 @@ matrix:
       env: TOXENV=django2-py35
     - python: "3.5"
       env: TOXENV=django21-py35
-    - python: "3.5.7"
-      sudo: required
-      dist: xenial
-      env: TOXENV=django22-py357
+    - python: "3.5"
+      env: TOXENV=django22-py35
 
     - python: "3.6"
       env: TOXENV=django111-py36
@@ -32,10 +30,10 @@ matrix:
       env: TOXENV=django2-py36
     - python: "3.6"
       env: TOXENV=django21-py36
-    - python: "3.6.8"
-      sudo: required
-      dist: xenial
-      env: TOXENV=django22-py368
+    - python: "3.6"
+      env: TOXENV=django22-py36
+    - python: "3.6"
+      env: TOXENV=django3-py36
 
     - python: "3.7"
       sudo: required
@@ -56,7 +54,20 @@ matrix:
     - python: "3.7"
       sudo: required
       dist: xenial
+      env: TOXENV=django3-py37
+    - python: "3.7"
+      sudo: required
+      dist: xenial
       env: TOXENV=pycodestyle-py37
+
+    - python: "3.8"
+      sudo: required
+      dist: xenial
+      env: TOXENV=django3-py38
+    - python: "3.8"
+      sudo: required
+      dist: xenial
+      env: TOXENV=pycodestyle-py38
 
 cache: pip
 

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -26,3 +26,4 @@ Other
 * `pbf <https://github.com/pbf>`_
 * `Alexey Subbotin <https://github.com/dotsbb>`_
 * `Sean Stewart <https://github.com/mindcruzer>`_
+* `Rob Charlwood <https://github.com/robcharlwood>`_

--- a/README.rst
+++ b/README.rst
@@ -26,13 +26,16 @@ Requirements
 
 Tested with:
 
-* Python: 2.7, 3.5.7, 3.6.8, 3.7
-* Django: 1.11, 2.0, 2.1, 2.2
+* Python: 2.7, 3.5, 3.6, 3.7, 3.8
+* Django: 1.11, 2.0, 2.1, 2.2, 3.0
 
 
 .. note::
-   Django 2.2 requires SQLite 3.8.3 or later, from the Django 2.2 release notes:
-   Django 2.2 supports Python 3.5, 3.6, and 3.7. We highly recommend and only officially support the latest release of each series.
+* Django 2.2 requires SQLite 3.8.3
+* Django 2.2 supports Python 3.5, 3.6, and 3.7. 
+* Django 3.0 supports Python 3.6, 3.7 and 3.8.
+We highly recommend and only officially support the latest release of each series.
+
 
 Installation
 ------------

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url='http://github.com/praekelt/django-recaptcha',
     packages=find_packages(),
     install_requires=[
-        'django>1.11,<3.0',
+        'django>1.11,<4.0',
     ],
     tests_require=[
         'tox',
@@ -25,6 +25,7 @@ setup(
     include_package_data=True,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
+        'Framework :: Django :: 3.0',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.0',
@@ -41,6 +42,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     zip_safe=False,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,20 @@
 [tox]
 envlist =
-    pycodestyle-{py27,py37},
+    pycodestyle-{py27,py37,py38}
     django{111,2,21}-{py27,py35,py36,py37}
-    django{22}-{py357,py368,py37}
+    django{22}-{py35,py36,py37}
+    django{3}-{py36,py37,py38}
 
 [testenv]
 deps =
-    django{111,2,21,22}: coverage
+    django{111,2,21,22,3}: coverage
     django111: Django<2.0
     django2: Django<2.1
     django21: Django<2.2
     django22: Django<3.0
+    django3: Django<4.0
     py27: -rcaptcha/tests/requirements/py27.txt
     pycodestyle: pycodestyle
 commands =
-    django{111,2,21,22}: coverage run manage.py test
+    django{111,2,21,22,3}: coverage run manage.py test
     pycodestyle: pycodestyle captcha/


### PR DESCRIPTION
Upgrades to ``tox`` and ``travis`` to run tests against Python 3.8 and Django 3.0.

Also fixes some ``tox`` checks that were failing due to the version numbers (``3.5.7`` and ``3.6.8``).

I am unable to complete an upgrade to Django until this is merged and released as ``setup.py`` pins Django to less than 3 in its ``install_requires``.