### PR TITLE
removed unused imports and fixed deprecation warning

### DIFF
--- a/captcha/client.py
+++ b/captcha/client.py
@@ -3,10 +3,9 @@ import json
 from django.conf import settings
 
 from captcha._compat import (
-    build_opener, ProxyHandler, PY2, Request, urlencode, urlopen
+    build_opener, ProxyHandler, PY2, Request, urlencode
 )
 from captcha.constants import DEFAULT_RECAPTCHA_DOMAIN
-from captcha.decorators import generic_deprecation
 
 
 RECAPTCHA_SUPPORTED_LANUAGES = ("en", "nl", "fr", "de", "pt", "ru", "es", "tr")

--- a/captcha/fields.py
+++ b/captcha/fields.py
@@ -1,20 +1,21 @@
 import logging
-import os
-import socket
 import sys
-import warnings
 
+import django
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.exceptions import ValidationError
-from django.utils.encoding import force_text
-from django.utils.translation import ugettext_lazy as _
+
+if django.VERSION[0] < 2:
+    from django.utils.translation import ugettext_lazy as _
+else:
+    from django.utils.translation import gettext_lazy as _
 
 from captcha import client
-from captcha._compat import HTTPError, urlencode
+from captcha._compat import HTTPError
 from captcha.constants import TEST_PRIVATE_KEY, TEST_PUBLIC_KEY
-from captcha.widgets import ReCaptchaV2Checkbox, ReCaptchaBase, ReCaptchaV3
+from captcha.widgets import ReCaptchaV2Checkbox, ReCaptchaBase
 
 
 logger = logging.getLogger(__name__)

--- a/captcha/tests/test_client.py
+++ b/captcha/tests/test_client.py
@@ -6,10 +6,9 @@ except ImportError:
     from mock import patch, PropertyMock, MagicMock
 
 from django import forms
-from django.conf import settings
 from django.test import TestCase, override_settings
 
-from captcha import client, constants, fields
+from captcha import client, fields
 
 
 class DefaultForm(forms.Form):

--- a/captcha/tests/test_fields.py
+++ b/captcha/tests/test_fields.py
@@ -1,7 +1,3 @@
-import os
-import uuid
-import warnings
-
 try:
     from unittest.mock import patch, PropertyMock, MagicMock
 except ImportError:
@@ -11,7 +7,7 @@ from django import forms
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
 
-from captcha import fields, widgets, constants
+from captcha import fields, widgets
 from captcha._compat import HTTPError
 from captcha.client import RecaptchaResponse
 

--- a/captcha/tests/tests.py
+++ b/captcha/tests/tests.py
@@ -3,7 +3,6 @@ try:
 except ImportError:
     pass
 
-from django.conf import settings
 from django.core.checks import Error
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings

--- a/captcha/widgets.py
+++ b/captcha/widgets.py
@@ -1,10 +1,7 @@
-import json
 import uuid
 
 from django.conf import settings
 from django.forms import widgets
-from django.utils.safestring import mark_safe
-from django.utils.translation import get_language
 
 from captcha._compat import urlencode
 from captcha.constants import DEFAULT_RECAPTCHA_DOMAIN


### PR DESCRIPTION
I removed unused imports that were made in multiple files.
Also, `ugettext_lazy` has been an alias for `ugettext` since django 2.0, and is [marked as deprecated](https://github.com/django/django/blob/3.1.2/django/utils/translation/__init__.py#L139) since django 3.1. However, it should still be used for django 1.X.

Note: `captcha.decorators.generic_deprecation` seems to be unused and may be removed in another PR