### PR TITLE
Added important step to Usage in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,19 @@ The quickest way to add reCAPTCHA to a form is to use the included
     class FormWithCaptcha(forms.Form):
         captcha = ReCaptchaField()
 
+If you are using a custom template for your form, you need to include the captcha field and errors. For example:
+
+.. code-block:: htmldjango
+
+    {% extends "layout.html" %}
+    {% load static %}
+    {% load i18n %}
+    {% block content %}
+    <form enctype="multipart/form-data" method="post" action="{{request.some_action_here}}">
+        {% ... lots of form markup here ... %}
+        {{form.captcha.errors}}{{form.captcha}}
+    </form>
+    {% endblock %}
 
 To allow for runtime specification of keys you can optionally pass the
 ``private_key`` or ``public_key`` parameters to the constructor. For example:


### PR DESCRIPTION
I wanted to add this block to the README as it was a real headscratcher as to why my captcha wasn't working. The solution here (to render the actual fields in the form) was nowhere to be found in the README or in any open issues in the repository. I suppose it may be quite obvious to those used to working with django, but for a newcomer like me, I guess I assumed the markup was injected into the form some (may be the case with other flows of creating a form in django, but like I said I'm a newcomer) 