### PR TITLE
Feature request: make returned score in captcha V3 accessible on backend

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -210,6 +210,20 @@ For per field, runtime, specification the attribute can also be passed to the wi
 
 In the event the score does not meet the requirements, the field validation will fail as expected and an error message will be logged.
 
+After validating the form, the score value returned by Google will be present in the widget attribute ``returned_score``. In the case of any error the value of ``returned_score`` will remain it's initial value of ``None``. The ``returned_score`` can be accessed in a view like so:
+
+    .. code-block:: python
+
+        if form.is_valid():
+            # code here
+        else:
+            # more code here
+        
+        # after running is_valid() returned_score should be set, if there were no errors:
+        if not form.fields['captcha'].widget.attrs['returned_score'] is None:
+            print('Google returned a score of:' + form.fields['captcha'].widget.attrs['returned_score'])
+        
+
 Local Development and Functional Testing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/captcha/fields.py
+++ b/captcha/fields.py
@@ -107,6 +107,9 @@ class ReCaptchaField(forms.CharField):
             # value back.
             score = float(check_captcha.extra_data.get("score", 0))
 
+            # Update widget attrs with returned_score
+            self.widget.attrs["returned_score"] = score
+
             if required_score > score:
                 logger.error(
                     "ReCAPTCHA validation failed due to its score of %s"

--- a/captcha/widgets.py
+++ b/captcha/widgets.py
@@ -80,6 +80,8 @@ class ReCaptchaV3(ReCaptchaBase):
             self.attrs["required_score"] = getattr(
                 settings, "RECAPTCHA_REQUIRED_SCORE", None
             )
+        if not self.attrs.get("returned_score", None):
+            self.attrs["returned_score"] = None
 
     def build_attrs(self, base_attrs, extra_attrs=None):
         attrs = super(ReCaptchaV3, self).build_attrs(


### PR DESCRIPTION
As requested / commented in https://github.com/praekelt/django-recaptcha/issues/226 - I used an additional attribute i.e. `attr` called `returned_score` which is set during validation with the returned score from google. 

Also updated the README with how to access this score in a view for example. It will be set in the widget after the validation code runs.

Let me know if this is a good way to go about it or if I am totally off the mark - would be happy to refactor or do it a different way to be able to have this functionality.

Like https://github.com/praekelt/django-recaptcha/issues/226 I am also interested in this functionality - our team would like to compare past scores and form field values to fine-tune the minimum required score on our site.

