### PR TITLE
Skip returning the captcha value, it's only useful for verification and useless later

### DIFF
--- a/captcha/fields.py
+++ b/captcha/fields.py
@@ -108,3 +108,7 @@ class ReCaptchaField(forms.CharField):
                 raise ValidationError(
                     self.error_messages["captcha_invalid"], code="captcha_invalid"
                 )
+
+    def clean(self, value):
+        super().clean(value)
+        return ""  # Do not return the captcha value, it won't be useful later.


### PR DESCRIPTION
`form.cleaned_data` contains a >500 characters long string with the captcha, but I don't really think that this string is useful at all later.

I don't think there's a way to remove the captcha field's key completely from the `cleaned_data` dictionary but that's fine.

I omitted the changelog entry because it would conflict with #293 